### PR TITLE
Refactor config builder to derive macros

### DIFF
--- a/payjoin-cli/src/app/config.rs
+++ b/payjoin-cli/src/app/config.rs
@@ -1,13 +1,12 @@
-use std::path::PathBuf;
-
 use anyhow::Result;
-use clap::ArgMatches;
 use config::builder::DefaultState;
 use config::{ConfigError, File, FileFormat};
 use payjoin::bitcoin::FeeRate;
 use serde::Deserialize;
+use std::path::PathBuf;
 use url::Url;
 
+use crate::cli::{Cli, Commands};
 use crate::db;
 
 type Builder = config::builder::ConfigBuilder<DefaultState>;
@@ -62,30 +61,7 @@ impl Config {
     const VERSION_FLAGS: &'static [(&'static str, u8)] = &[("bip77", 2), ("bip78", 1)];
 
     /// Check for multiple version flags and return the highest precedence version
-    fn determine_version(matches: &ArgMatches) -> Result<u8, ConfigError> {
-        let mut selected_version = None;
-        for &(flag, version) in Self::VERSION_FLAGS.iter() {
-            if matches.get_flag(flag) {
-                if selected_version.is_some() {
-                    return Err(ConfigError::Message(format!(
-                        "Multiple version flags specified. Please use only one of: {}",
-                        Self::VERSION_FLAGS
-                            .iter()
-                            .map(|(flag, _)| format!("--{flag}"))
-                            .collect::<Vec<_>>()
-                            .join(", ")
-                    )));
-                }
-                selected_version = Some(version);
-            }
-        }
-
-        if let Some(version) = selected_version {
-            return Ok(version);
-        }
-
-        #[cfg(feature = "v2")]
-        return Ok(2);
+    fn determine_version(cli: &Cli) -> Result<u8, ConfigError> {
         #[cfg(all(feature = "v1", not(feature = "v2")))]
         return Ok(1);
 
@@ -93,20 +69,52 @@ impl Config {
         return Err(ConfigError::Message(
             "No valid version available - must compile with v1 or v2 feature".to_string(),
         ));
+
+        let mut selected_version = None;
+
+        // Check for BIP77 (v2)
+        if cli.flags.bip77.unwrap_or(false) {
+            selected_version = Some(2);
+        }
+
+        // Check for BIP78 (v1)
+        if cli.flags.bip78.unwrap_or(false) {
+            if selected_version.is_some() {
+                return Err(ConfigError::Message(
+                    "Multiple version flags specified. Please use only one of: --bip77, --bip78"
+                        .to_string(),
+                ));
+            }
+            selected_version = Some(1);
+        }
+
+        // If no version explicitly selected, use default based on available features
+        if selected_version.is_none() {
+            #[cfg(feature = "v2")]
+            return Ok(2);
+            #[cfg(all(feature = "v1", not(feature = "v2")))]
+            return Ok(1);
+            #[cfg(not(any(feature = "v1", feature = "v2")))]
+            return Err(ConfigError::Message(
+                "No valid version available - must compile with v1 or v2 feature".to_string(),
+            ));
+        }
+
+        Ok(selected_version.unwrap())
     }
 
-    pub(crate) fn new(matches: &ArgMatches) -> Result<Self, ConfigError> {
-        let mut builder = config::Config::builder();
-        builder = add_bitcoind_defaults(builder, matches)?;
-        builder = add_common_defaults(builder, matches)?;
+    pub(crate) fn new(cli: &Cli) -> Result<Self, ConfigError> {
+        let mut config = config::Config::builder();
+        config = add_bitcoind_defaults(config, cli)?;
+        config = add_common_defaults(config, cli)?;
 
-        let version = Self::determine_version(matches)?;
+        let version = Self::determine_version(cli)?;
 
         match version {
             1 => {
                 #[cfg(feature = "v1")]
                 {
-                    builder = add_v1_defaults(builder)?;
+                    config = add_v1_defaults(config, cli)?;
                 }
                 #[cfg(not(feature = "v1"))]
                 return Err(ConfigError::Message(
@@ -116,7 +124,7 @@ impl Config {
             2 => {
                 #[cfg(feature = "v2")]
                 {
-                    builder = add_v2_defaults(builder, matches)?;
+                    config = add_v2_defaults(config, cli)?;
                 }
                 #[cfg(not(feature = "v2"))]
                 return Err(ConfigError::Message(
@@ -126,10 +134,10 @@ impl Config {
             _ => unreachable!("determine_version() should only return 1 or 2"),
         }
 
-        builder = handle_subcommands(builder, matches)?;
-        builder = builder.add_source(File::new("config.toml", FileFormat::Toml).required(false));
+        config = handle_subcommands(config, cli)?;
+        config = config.add_source(File::new("config.toml", FileFormat::Toml).required(false));
 
-        let built_config = builder.build()?;
+        let built_config = config.build()?;
 
         let mut config = Config {
             db_path: built_config.get("db_path")?,
@@ -144,10 +152,11 @@ impl Config {
                 {
                     match built_config.get::<V1Config>("v1") {
                         Ok(v1) => config.version = Some(VersionConfig::V1(v1)),
-                        Err(e) =>
+                        Err(e) => {
                             return Err(ConfigError::Message(format!(
                                 "Valid V1 configuration is required for BIP78 mode: {e}"
-                            ))),
+                            )))
+                        }
                     }
                 }
                 #[cfg(not(feature = "v1"))]
@@ -160,10 +169,11 @@ impl Config {
                 {
                     match built_config.get::<V2Config>("v2") {
                         Ok(v2) => config.version = Some(VersionConfig::V2(v2)),
-                        Err(e) =>
+                        Err(e) => {
                             return Err(ConfigError::Message(format!(
                                 "Valid V2 configuration is required for BIP77 mode: {e}"
-                            ))),
+                            )))
+                        }
                     }
                 }
                 #[cfg(not(feature = "v2"))]
@@ -204,101 +214,83 @@ impl Config {
 }
 
 /// Set up default values and CLI overrides for Bitcoin RPC connection settings
-fn add_bitcoind_defaults(builder: Builder, matches: &ArgMatches) -> Result<Builder, ConfigError> {
-    builder
-        .set_default("bitcoind.rpchost", "http://localhost:18443")?
-        .set_override_option(
-            "bitcoind.rpchost",
-            matches.get_one::<Url>("rpchost").map(|s| s.as_str()),
-        )?
-        .set_default("bitcoind.cookie", None::<String>)?
-        .set_override_option(
-            "bitcoind.cookie",
-            matches.get_one::<String>("cookie_file").map(|s| s.as_str()),
-        )?
-        .set_default("bitcoind.rpcuser", "bitcoin")?
-        .set_override_option(
-            "bitcoind.rpcuser",
-            matches.get_one::<String>("rpcuser").map(|s| s.as_str()),
-        )?
-        .set_default("bitcoind.rpcpassword", "")?
-        .set_override_option(
-            "bitcoind.rpcpassword",
-            matches.get_one::<String>("rpcpassword").map(|s| s.as_str()),
-        )
+fn add_bitcoind_defaults(config: Builder, cli: &Cli) -> Result<Builder, ConfigError> {
+    // Set default values
+    let config = config.set_default("bitcoind.rpchost", "http://localhost:18443")?;
+
+    // Override config values with command line arguments if applicable
+    let rpchost = cli.rpchost.as_ref().map(|s| s.as_str());
+    let cookie_file = cli.cookie_file.as_ref().map(|p| p.to_string_lossy().into_owned());
+    let rpcuser = cli.rpcuser.as_deref();
+    let rpcpassword = cli.rpcpassword.as_deref();
+
+    config
+        .set_override_option("bitcoind.rpchost", rpchost)?
+        .set_override_option("bitcoind.cookie", cookie_file)?
+        .set_override_option("bitcoind.rpcuser", rpcuser)?
+        .set_override_option("bitcoind.rpcpassword", rpcpassword)
 }
 
-/// Set up default values and CLI overrides for common settings shared between v1 and v2
-fn add_common_defaults(builder: Builder, matches: &ArgMatches) -> Result<Builder, ConfigError> {
-    builder
-        .set_default("db_path", db::DB_PATH)?
-        .set_override_option("db_path", matches.get_one::<String>("db_path").map(|s| s.as_str()))
+fn add_common_defaults(config: Builder, cli: &Cli) -> Result<Builder, ConfigError> {
+    let db_path = cli.db_path.as_ref().map(|p| p.to_string_lossy().into_owned());
+    config.set_default("db_path", db::DB_PATH)?.set_override_option("db_path", db_path)
 }
 
-/// Set up default values for v1-specific settings when v2 is not enabled
 #[cfg(feature = "v1")]
-fn add_v1_defaults(builder: Builder) -> Result<Builder, ConfigError> {
-    builder
+fn add_v1_defaults(config: Builder, cli: &Cli) -> Result<Builder, ConfigError> {
+    // Set default values
+    let config = config
         .set_default("v1.port", 3000_u16)?
-        .set_default("v1.pj_endpoint", "https://localhost:3000")
+        .set_default("v1.pj_endpoint", "https://localhost:3000")?;
+
+    // Override config values with command line arguments if applicable
+    let pj_endpoint = cli.pj_endpoint.as_ref().map(|s| s.as_str());
+
+    config
+        .set_override_option("v1.port", cli.port)?
+        .set_override_option("v1.pj_endpoint", pj_endpoint)
 }
 
 /// Set up default values and CLI overrides for v2-specific settings
 #[cfg(feature = "v2")]
-fn add_v2_defaults(builder: Builder, matches: &ArgMatches) -> Result<Builder, ConfigError> {
-    builder
-        .set_override_option(
-            "v2.ohttp_relay",
-            matches.get_one::<Url>("ohttp_relay").map(|s| s.as_str()),
-        )?
+fn add_v2_defaults(config: Builder, cli: &Cli) -> Result<Builder, ConfigError> {
+    config
+        .set_override_option("v2.ohttp_relay", cli.ohttp_relay.as_ref().map(|s| s.as_str()))?
         .set_default("v2.pj_directory", "https://payjo.in")?
         .set_default("v2.ohttp_keys", None::<String>)
 }
 
 /// Handles configuration overrides based on CLI subcommands
-fn handle_subcommands(builder: Builder, matches: &ArgMatches) -> Result<Builder, ConfigError> {
-    match matches.subcommand() {
-        Some(("send", _)) => Ok(builder),
-        Some(("receive", matches)) => {
-            let builder = handle_receive_command(builder, matches)?;
-            let max_fee_rate = matches.get_one::<FeeRate>("max_fee_rate");
-            builder.set_override_option("max_fee_rate", max_fee_rate.map(|f| f.to_string()))
+fn handle_subcommands(config: Builder, cli: &Cli) -> Result<Builder, ConfigError> {
+    match &cli.command {
+        Commands::Send { .. } => Ok(config),
+        Commands::Receive {
+            #[cfg(feature = "v1")]
+            port,
+            #[cfg(feature = "v1")]
+            pj_endpoint,
+            #[cfg(feature = "v2")]
+            pj_directory,
+            #[cfg(feature = "v2")]
+            ohttp_keys,
+            ..
+        } => {
+            #[cfg(feature = "v1")]
+            let config = config
+                .set_override_option("v1.port", port.map(|p| p.to_string()))?
+                .set_override_option("v1.pj_endpoint", pj_endpoint.as_ref().map(|s| s.as_str()))?;
+            #[cfg(feature = "v2")]
+            let config = config
+                .set_override_option("v2.pj_directory", pj_directory.as_ref().map(|s| s.as_str()))?
+                .set_override_option(
+                    "v2.ohttp_keys",
+                    ohttp_keys.as_ref().map(|s| s.to_string_lossy().into_owned()),
+                )?;
+            Ok(config)
         }
         #[cfg(feature = "v2")]
-        Some(("resume", _)) => Ok(builder),
-        _ => unreachable!(), // If all subcommands are defined above, anything else is unreachabe!()
+        Commands::Resume => Ok(config),
     }
-}
-
-/// Handle configuration overrides specific to the receive command
-fn handle_receive_command(builder: Builder, matches: &ArgMatches) -> Result<Builder, ConfigError> {
-    #[cfg(feature = "v1")]
-    let builder = {
-        let port = matches
-            .get_one::<String>("port")
-            .map(|port| port.parse::<u16>())
-            .transpose()
-            .map_err(|_| ConfigError::Message("\"port\" must be a valid number".to_string()))?;
-        builder.set_override_option("v1.port", port)?.set_override_option(
-            "v1.pj_endpoint",
-            matches.get_one::<Url>("pj_endpoint").map(|s| s.as_str()),
-        )?
-    };
-
-    #[cfg(feature = "v2")]
-    let builder = {
-        builder
-            .set_override_option(
-                "v2.pj_directory",
-                matches.get_one::<Url>("pj_directory").map(|s| s.as_str()),
-            )?
-            .set_override_option(
-                "v2.ohttp_keys",
-                matches.get_one::<String>("ohttp_keys").map(|s| s.as_str()),
-            )?
-    };
-
-    Ok(builder)
 }
 
 #[cfg(feature = "v2")]

--- a/payjoin-cli/src/cli/mod.rs
+++ b/payjoin-cli/src/cli/mod.rs
@@ -1,0 +1,133 @@
+use std::path::PathBuf;
+use clap::{Parser, Subcommand, value_parser};
+use payjoin::bitcoin::{amount::ParseAmountError, Amount, FeeRate};
+use serde::Deserialize;
+use url::Url;
+
+#[derive(Debug, Clone, Deserialize, Parser)]
+pub struct Flags {
+    #[arg(long = "bip77", help = "Use BIP77 (v2) protocol (default)", action = clap::ArgAction::SetTrue)]
+    pub bip77: Option<bool>,
+    #[arg(long = "bip78", help = "Use BIP78 (v1) protocol", action = clap::ArgAction::SetTrue)]
+    pub bip78: Option<bool>
+}
+
+#[derive(Debug, Parser)]
+#[command(
+    version = env!("CARGO_PKG_VERSION"),
+    about = "Payjoin - bitcoin scaling, savings, and privacy by default",
+    long_about = None, 
+    subcommand_required = true
+)]
+pub struct Cli {
+    #[command(flatten)]
+    pub flags: Flags,
+
+    #[command(subcommand)]
+    pub command: Commands,
+
+    #[arg(long, short = 'd', help = "Sets a custom database path")]
+    pub db_path: Option<PathBuf>,
+
+    #[arg(long = "max-fee-rate", short = 'f', help = "The maximum fee rate to accept in sat/vB")]
+    pub max_fee_rate: Option<FeeRate>,
+
+    #[arg(
+        long,
+        short = 'r',
+        num_args(1),
+        help = "The URL of the Bitcoin RPC host, e.g. regtest default is http://localhost:18443"
+    )]
+    pub rpchost: Option<Url>,
+
+    #[arg(
+        long = "cookie-file",
+        short = 'c',
+        num_args(1),
+        help = "Path to the cookie file of the bitcoin node"
+    )]
+    pub cookie_file: Option<PathBuf>,
+
+    #[arg(long = "rpcuser", num_args(1), help = "The username for the bitcoin node")]
+    pub rpcuser: Option<String>,
+
+    #[arg(long = "rpcpassword", num_args(1), help = "The password for the bitcoin node")]
+    pub rpcpassword: Option<String>,
+
+    #[cfg(feature = "v1")]
+    #[arg(long = "port", help = "The local port to listen on")]
+    pub port: Option<u16>,
+
+    #[cfg(feature = "v1")]
+    #[arg(long = "pj-endpoint", help = "The `pj=` endpoint to receive the payjoin request", value_parser = value_parser!(Url))]
+    pub pj_endpoint: Option<Url>,
+
+    #[cfg(feature = "v2")]
+    #[arg(long = "ohttp-relay", help = "The ohttp relay url", value_parser = value_parser!(Url))]
+    pub ohttp_relay: Option<Url>,
+
+    #[cfg(feature = "v2")]
+    #[arg(long = "ohttp-keys", help = "The ohttp key config file path", value_parser = value_parser!(PathBuf))]
+    pub ohttp_keys: Option<PathBuf>,
+
+    #[cfg(feature = "v2")]
+    #[arg(long = "pj-directory", help = "The directory to store payjoin requests", value_parser = value_parser!(Url))]
+    pub pj_directory: Option<Url>,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    /// Send a payjoin payment
+    Send {
+        /// The `bitcoin:...` payjoin uri to send to
+        #[arg(required = true)]
+        bip21: String,
+
+        /// Fee rate in sat/vB
+        #[arg(short, long = "fee-rate", value_parser = parse_fee_rate_in_sat_per_vb)]
+        fee_rate: Option<FeeRate>,
+    },
+    /// Receive a payjoin payment
+    Receive {
+        /// The amount to receive in satoshis
+        #[arg(required = true, value_parser = parse_amount_in_sat)]
+        amount: Amount,
+
+        /// The maximum effective fee rate the receiver is willing to pay (in sat/vB)
+        #[arg(short, long = "max-fee-rate", value_parser = parse_fee_rate_in_sat_per_vb)]
+        max_fee_rate: Option<FeeRate>,
+
+        #[cfg(feature = "v1")]
+        /// The local port to listen on
+        #[arg(short, long = "port")]
+        port: Option<u16>,
+
+        #[cfg(feature = "v1")]
+        /// The `pj=` endpoint to receive the payjoin request
+        #[arg(long = "pj-endpoint", value_parser = value_parser!(Url))]
+        pj_endpoint: Option<Url>,
+
+        #[cfg(feature = "v2")]
+        /// The directory to store payjoin requests
+        #[arg(long = "pj-directory", value_parser = value_parser!(Url))]
+        pj_directory: Option<Url>,
+
+        #[cfg(feature = "v2")]
+        /// The path to the ohttp keys file
+        #[arg(long = "ohttp-keys", value_parser = value_parser!(Url))]
+        ohttp_keys: Option<PathBuf>,
+    },
+    /// Resume pending payjoins (BIP77/v2 only)
+    #[cfg(feature = "v2")]
+    Resume,
+}
+
+pub fn parse_amount_in_sat(s: &str) -> Result<Amount, ParseAmountError> {
+    Amount::from_str_in(s, payjoin::bitcoin::Denomination::Satoshi)
+}
+
+pub fn parse_fee_rate_in_sat_per_vb(s: &str) -> Result<FeeRate, std::num::ParseFloatError> {
+    let fee_rate_sat_per_vb: f32 = s.parse()?;
+    let fee_rate_sat_per_kwu = fee_rate_sat_per_vb * 250.0_f32;
+    Ok(FeeRate::from_sat_per_kwu(fee_rate_sat_per_kwu.ceil() as u64))
+}

--- a/payjoin-cli/tests/e2e.rs
+++ b/payjoin-cli/tests/e2e.rs
@@ -192,6 +192,8 @@ mod e2e {
             services.wait_for_services_ready().await?;
             let ohttp_keys = services.fetch_ohttp_keys().await?;
             let ohttp_keys_path = temp_dir.join("ohttp_keys");
+            println!("ohttp keys: {ohttp_keys:#?}");
+            println!("ohttp path: {ohttp_keys_path:?}");
             tokio::fs::write(&ohttp_keys_path, ohttp_keys.encode()?).await?;
 
             let receiver_rpchost = format!("http://{}/wallet/receiver", bitcoind.params.rpc_socket);


### PR DESCRIPTION
Error output upon running `./contrib/test_local.sh`

```sh
error: Invalid value '/tmp/ohttp_keys' for '--ohttp-keys <OHTTP_KEYS>': relative URL without a base

For more information try '--help'
test e2e::send_receive_payjoin_v2 ... FAILED

failures:

---- e2e::send_receive_payjoin_v2 stdout ----
Database running on 127.0.0.1:32873
Directory server binding to port [::]:33899
OHTTP relay binding to port [::]:43911
ohttp keys: OhttpKeys(
    KeyConfig {
        key_id: 1,
        kem: K256Sha256,
        symmetric: [
            SymmetricSuite {
                kdf: HkdfSha256,
                aead: ChaCha20Poly1305,
            },
        ],
        sk: None,
        pk: PublicKey 04a7c1aecb00da5650f176516d31692e459182f9725424deef5c87cc1da96293f7b4bac6317834ff309c5a826ce910ed95a4bf06354b8a72b17a556d2cbdca1f59,
    },
)
ohttp path: "/tmp/ohttp_keys"
2025-05-19T13:39:05.136997Z ERROR ohttp_relay::bootstrap::connect: server io error: Transport endpoint is not connected (os error 107)

thread 'e2e::send_receive_payjoin_v2' panicked at payjoin-cli/tests/e2e.rs:291:14:
payjoin-cli receiver should output a bitcoin URI
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Failed to remove "/tmp/receiver_db": No such file or directory (os error 2)
Failed to remove "/tmp/sender_db": No such file or directory (os error 2)


failures:
    e2e::send_receive_payjoin_v2

test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 4.54s

error: test failed, to rerun pass `-p payjoin-cli --test e2e`
```